### PR TITLE
Make SmallGrp a needed rather than a suggested package

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -67,8 +67,8 @@ PackageDoc := rec(
 
 Dependencies := rec(
     GAP := ">= 4.14",
-    NeededOtherPackages := [],
-    SuggestedOtherPackages := [ [ "smallgrp", "1.5.4" ] ],
+    NeededOtherPackages := [ [ "smallgrp", "1.5.4" ] ],
+    SuggestedOtherPackages := [],
     TestPackages := [
         [ "primgrp",  "3.4.4" ],
         [ "transgrp", "3.6.5" ],


### PR DESCRIPTION
SmallClassNr identifies a group via IdClassNr, which narrows down the
candidates using three fingerprints; one of them, SCN.FingerPrint.Fitting
in lib/basic.g, is the IdGroup of the Fitting subgroup. That is core
functionality, so SmallGrp should be a needed package rather than a
suggested one.

Without it, three tests failed:

    Error, the Small Groups library is required but not installed
    Error, Variable: 'IdGroupsAvailable' must have an assigned value

Note the second one: IdGroupsAvailable was used to check whether the
small groups library has data for a given order, but that function is
itself only available if SmallGrp is loaded.

See https://github.com/gap-system/gap/issues/2434

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
